### PR TITLE
[docs]: Add specification and config docs

### DIFF
--- a/content/docs/configuration/content.md
+++ b/content/docs/configuration/content.md
@@ -13,9 +13,9 @@ title = "Configuration"
 
 ---
 
-### Supported redirect types:
+## Supported redirect types:
 
-| Type Name | Type Information                                            |
+| Type Name | Type Description                                            |
 | --------- | ----------------------------------------------------------- |
 | www       | Redirect all requests to "www"-subdomain                    |
 | host      | Redirect to host provided in TXT record                     |
@@ -27,7 +27,7 @@ title = "Configuration"
 
 ---
 
-### Enable types
+## Enable type
 
 ```
 txtdirect {
@@ -35,7 +35,7 @@ txtdirect {
 }
 ```
 
-### Enable multiple types
+## Enable multiple types
 
 ```
 txtdirect {
@@ -43,7 +43,7 @@ txtdirect {
 }
 ```
 
-### Disable types
+## Disable type
 
 ```
 txtdirect {
@@ -52,6 +52,8 @@ txtdirect {
 ```
 
 # Fallback
+
+---
 
 ## Flow
 
@@ -87,3 +89,89 @@ txtdirect {
   redirect https://example.com
 }
 ```
+
+# Prometheus Metrics
+
+---
+
+## Metrics name
+
+| Metric Name                           | Metric Description                         |
+| ------------------------------------- | ------------------------------------------ |
+| txtdirect_redirect_count_total        | Total requests per host                    |
+| txtdirect_redirect_status_count_total | Total returned statuses per host           |
+| txtdirect_redirect_type_count_total   | Total requests for each host based on type |
+| txtdirect_fallback_type_count_total   | Total fallbacks triggered for each type    |
+| txtdirect_redirect_path_count_total   | Total redirects per path for each host     |
+
+## Prometheus config
+
+You can either use the default settings for enabling Promethues metrics or the advanced config to provide a custom address and path for exporting metrics.
+
+### Enable Prometheus metrics
+
+```
+txtdirect {
+  prometheus
+}
+```
+
+### Advanced config
+
+```
+txtdirect {
+  prometheus {
+    address 192.168.0.1:6543
+    path /mymetrics
+  }
+}
+```
+
+# Gomods
+
+---
+
+## Enable Gomods
+
+```
+txtdirect {
+  enable gomods
+}
+```
+
+## Advanced config
+
+```
+txtdirect {
+  gomods {
+    gobinary /usr/bin/go
+    workers 2
+  }
+}
+```
+
+## Gomods Cache
+
+---
+
+### Supported cache types
+
+| Type Name | Type Description                             |
+| --------- | -------------------------------------------- |
+| local     | Caches the packages in the local file system |
+| tmp       | Caches the packages in /tmp directory        |
+
+### Config
+
+```
+txtdirect {
+  gomods {
+    cache {
+      type local
+      path /home/user/gomods_cache
+    }
+  }
+}
+```
+
+---

--- a/content/docs/configuration/content.md
+++ b/content/docs/configuration/content.md
@@ -6,58 +6,84 @@ title = "Configuration"
 
 [sidebar]
   enable = true
+  sticky = true
 +++
 
-**Redirect all requests to "www"-subdomain:**  
-*example.com -> www.example.com*
+# Redirect Types
+
+---
+
+### Supported redirect types:
+
+| Type Name | Type Information                                            |
+| --------- | ----------------------------------------------------------- |
+| www       | Redirect all requests to "www"-subdomain                    |
+| host      | Redirect to host provided in TXT record                     |
+| path      | Enable path based redirects                                 |
+| gometa    | Enable Go packages meta/vanity redirects                    |
+| gomods    | Enable serving and caching Go modules                       |
+| dockerv2  | Redirect to docker registry or image provided in TXT record |
+| proxy     | Proxy the request to endpoint provided in TXT record        |
+
+---
+
+### Enable types
+
 ```
 txtdirect {
   enable www
 }
 ```
 
-**Redirect to host provided in TXT record:**  
-*Fallback: Return 404 on empty record*
+### Enable multiple types
+
 ```
 txtdirect {
-  enable host
+  enable host path gomods dockerv2
 }
 ```
 
-**Redirect to host provided in TXT record:**  
-*Fallback: Redirect to "www"-subdomain on empty record*
+### Disable types
+
 ```
 txtdirect {
-  enable host www
+  disable www
 }
 ```
 
-**Redirect to host provided in TXT record:**  
-*Fallback: Redirect to example.com on empty record*
+# Fallback
+
+## Flow
+
+Step-by-Step fallback flow:
+
+- Specific record's `to=` field
+- Specific record's `website=` field
+- Specific record's `root=` field
+- Second to last record's `website=` field
+- Second to last record's `root=` field
+- Second to last record's `to=` field
+- Request's host "www"-subdomain
+- Global config's `redirect` field
+- 404 Status code
+
+_hint: **Specific record** is the last TXT record found_  
+_hint 2: **Second to last record** is the last path record leading to the **Specific record**_
+
+## Global fallback config
+
+### Enable "www"-subdomain fallback
+
+```
+txtdirect {
+  enable www
+}
+```
+
+### Default `redirect` fallback
+
 ```
 txtdirect {
   redirect https://example.com
-}
-```
-
-**Enable path based redirects:**  
-```
-txtdirect {
-    enable host path
-}
-```
-
-**Enable go meta/vanity redirects:**  
-*pkg.example.com -> github.com/some/pkg.git*
-```
-txtdirect {
-  enable gometa
-}
-```
-
-**Enable everything except "www"-subdomain redirection:**  
-```
-txtdirect {
-    disable www
 }
 ```

--- a/content/docs/configuration/content.md
+++ b/content/docs/configuration/content.md
@@ -13,21 +13,21 @@ title = "Configuration"
 
 ---
 
-## Supported redirect types:
+## Supported redirect types
 
 | Type Name | Type Description                                            |
 | --------- | ----------------------------------------------------------- |
 | www       | Redirect all requests to "www"-subdomain                    |
 | host      | Redirect to host provided in TXT record                     |
 | path      | Enable path based redirects                                 |
-| gometa    | Enable Go packages meta/vanity redirects                    |
+| gometa    | Enable Go package meta/vanity redirects                     |
 | gomods    | Enable serving and caching Go modules                       |
 | dockerv2  | Redirect to docker registry or image provided in TXT record |
 | proxy     | Proxy the request to endpoint provided in TXT record        |
 
 ---
 
-## Enable type
+## Enable single type
 
 ```
 txtdirect {
@@ -43,7 +43,7 @@ txtdirect {
 }
 ```
 
-## Disable type
+## Disable specific type
 
 ```
 txtdirect {
@@ -59,18 +59,15 @@ txtdirect {
 
 Step-by-Step fallback flow:
 
-- Specific record's `to=` field
-- Specific record's `website=` field
-- Specific record's `root=` field
-- Second to last record's `website=` field
-- Second to last record's `root=` field
-- Second to last record's `to=` field
-- Request's host "www"-subdomain
-- Global config's `redirect` field
+- Current TXT record's `to=` field
+- Current TXT record's `website=` field
+- Current TXT record's `root=` field
+- Parent (type=path) TXT record's `website=` field
+- Parent (type=path) TXT record's `root=` field
+- Parent (type=path) TXT record's `to=` field
+- Request's host "www"-subdomain (if enabled)
+- Global config's `redirect` field (if configured)
 - 404 Status code
-
-_hint: **Specific record** is the last TXT record found_  
-_hint 2: **Second to last record** is the last path record leading to the **Specific record**_
 
 ## Global fallback config
 
@@ -106,7 +103,7 @@ txtdirect {
 
 ## Prometheus config
 
-You can either use the default settings for enabling Promethues metrics or the advanced config to provide a custom address and path for exporting metrics.
+You can either use the default settings for enabling Prometheus metrics or the advanced config to provide a custom address and path for exporting metrics.
 
 ### Enable Prometheus metrics
 
@@ -208,7 +205,7 @@ txtdirect {
 
 ---
 
-To use a custom DNS resolver instead of machine's default resolver, you can provide the `resolver` address in the config.
+To use a custom DNS resolver instead of the machine's default resolver, you can provide the `resolver` address in the config.
 
 ## Config
 

--- a/content/docs/configuration/content.md
+++ b/content/docs/configuration/content.md
@@ -174,4 +174,46 @@ txtdirect {
 }
 ```
 
+# QR
+
 ---
+
+By enabling QR, if the incoming request has a "?qr" query, TXTDirect will serve the request's URI QR code.
+
+## Config
+
+By providing additional configs like size, background color, and foreground color you can configure how the generated QR codes look.
+
+### Enable QR
+
+```
+txtdirect {
+  qr
+}
+```
+
+### Advanced config
+
+```
+txtdirect {
+  qr {
+    size 512
+    background #ffffff
+    foreground #000000
+  }
+}
+```
+
+# DNS Resolver
+
+---
+
+To use a custom DNS resolver instead of machine's default resolver, you can provide the `resolver` address in the config.
+
+## Config
+
+```
+txtdirect {
+  resolver 127.0.0.1:5353
+}
+```

--- a/content/docs/specification/content.md
+++ b/content/docs/specification/content.md
@@ -143,7 +143,7 @@ If a custom regex is configured with the `re=` field each match is used as a sub
 
 - Key: **from**
 - Permitted values: "simplified regex"
-- Example: "from=/$2/$1/\$3"
+- Example: "from=/$2/$1/$3"
 
 **Regex**
 
@@ -289,7 +289,7 @@ The `gomods` type doesn't require any specific config in the DNS records and get
 
 ## Description
 
-The `proxy` type let's you to proxy your requests to a specific endpoint. It reads the endpoint from record's `to=` field and reverse proxies the requst to the endpoint.
+The `proxy` type let's you proxy your requests to a specific upstream. It reads the upstream from the record's `to=` field and reverse proxies the request.
 
 **Type**
 

--- a/content/docs/specification/content.md
+++ b/content/docs/specification/content.md
@@ -143,7 +143,7 @@ If a custom regex is configured with the `re=` field each match is used as a sub
 
 - Key: **from**
 - Permitted values: "simplified regex"
-- Example: "from=/$2/$1/$3"
+- Example: "from=/$2/$1/\$3"
 
 **Regex**
 
@@ -211,7 +211,6 @@ The upstream endpoint used for `to=` can be different depending on the use case.
 The `gometa` type enables vanity URLs for your Go packages. Using your own URL for packages, enables easier switching between your backend hosting service (GitHub, etc.) and lets you have custom import path for your package, independent of your hosting service. Using `gometa` you can switch your hosting service without worrying about impacting downstream for your users.
 Using `gometa` type you can point to a Go package inside your records using the `to=` field and we use that URI to generate a simple HTML page that only contains go-import and go-source **(Only for packages served on GitHub)** tags for `go get` to use it and find your package.
 
-
 ## Record fields
 
 **Type**
@@ -260,7 +259,37 @@ Using `gometa` type you can point to a Go package inside your records using the 
 
 ---
 
+# Gomods Type
+
+## Description
+
+The `gomods` type provides vanity urls for Go modules. It uses the request's path to identify a Go package's import path. Then it fetches the package and module files like `info`, `mod` and `zip` to serve a `go get` request. `gomods` supports all the hosting services and VCS` that are supported by Go tools.
+
+It also provides local caching for Go modules. You can also define a custom Go binary for fetching the modules and a custom number of workers for the module downloader's stash.
+
+The `gomods` type doesn't require any specific config in the DNS records and gets configured in the [TXTDirect config](/docs/configuration#gomods-config).
+
+**Type**
+
+- Key: **type**
+- Mandatory
+- Permitted values: "gomods"
+- Example: "type=gomods"
+
+**Version**
+
+- Key: **v**
+- Mandatory
+- Permitted values: "txtv0"
+- Example: "v=txtv0"
+
+---
+
 # Proxy Type (experimental)
+
+## Description
+
+The `proxy` type let's you to proxy your requests to a specific endpoint. It reads the endpoint from record's `to=` field and reverse proxies the requst to the endpoint.
 
 **Type**
 
@@ -282,30 +311,3 @@ Using `gometa` type you can point to a Go package inside your records using the 
 - Mandatory
 - Permitted values: "absolute URL"
 - Example: "to=https://example.com/subpage/"
-
----
-
-# Tor Type (experimental)
-
-**Type**
-
-- Key: **type**
-- Mandatory
-- Permitted values: "tor"
-- Example: "type=tor"
-
-**Version**
-
-- Key: **v**
-- Mandatory
-- Permitted values: "txtv0"
-- Example: "v=txtv0"
-
-**Upstream URL**
-
-- Key: **to**
-- Mandatory
-- Permitted values: "absolute URL"
-- Example: "to=http://3g2upl4pq6kufc4m.onion/"
-
-<!--root/website?-->


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds specification and config docs for all types.

TODO:

- [x] Gomods specification
- [x] Proxy description
- [x] Prometheus config
- [x] Gomods config
- [x] QR config
- [x] Resolver config
- [ ] wildcard documentation


**Which issue this PR fixes**:
fixes txtdirect/txtdirect#275


**Special notes for your reviewer**:
Will add all things that need documentation to the todo list to be sure we don't miss anything.
